### PR TITLE
Add video recording and link in HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,7 @@ pytest --html=report.html --self-contained-html
 ### Test Report
 Viewing the Test Report
 After test execution, a file named report.html is generated in the project root.
-Open report.html in your web browser to view detailed test results (including screenshots).
+Open report.html in your web browser to view detailed test results.  Each test
+captures screenshots and a short video regardless of test success or failure.
+Videos are saved under the `videos` directory and the report contains links to
+download them.


### PR DESCRIPTION
## Summary
- record browser video for each test via Playwright
- store recorded videos and add link in pytest-html report
- document video feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68404bf51b4c8330b4e0a31e221ff74c